### PR TITLE
Adds path.join

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -27,9 +27,9 @@ function activate(context) {
 		let javaFile = vscode.window.activeTextEditor.document.fileName;
 		let javaFilePath = path.dirname(javaFile);
 		let filePath = vscode.workspace.rootPath;
-		let buildPath = filePath + "/build-jar";
+		let buildPath = path.join(filePath, "build-jar");
 		let editorFile = path.basename(javaFile, path.extname(javaFile));
-		let jarFile = buildPath + `/${editorFile}.jar`;
+		let jarFile = path.join(buildPath, `${editorFile}.jar`);
 
 		let command = `rm -rf ${buildPath} && mkdir ${buildPath} && javac -d ${buildPath} ${javaFilePath}/* && jar cvf ${jarFile} ${buildPath} *`;
 


### PR DESCRIPTION
Using path.join is safer than concatenating paths' strings together because it always returns the correct path regardless of which OS the script is running on.